### PR TITLE
feat(4): Add and Edit recipe forms

### DIFF
--- a/frontend/src/api/recipes.js
+++ b/frontend/src/api/recipes.js
@@ -3,6 +3,10 @@ const BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:3001'
 async function handleResponse(res) {
   if (!res.ok) {
     const body = await res.json().catch(() => ({}))
+    // express-validator returns { errors: [{msg, ...}] }; pass array as JSON string
+    if (body.errors && Array.isArray(body.errors)) {
+      throw new Error(JSON.stringify(body.errors))
+    }
     const message = body.error || body.message || `HTTP ${res.status}`
     throw new Error(message)
   }

--- a/frontend/src/components/RecipeForm.css
+++ b/frontend/src/components/RecipeForm.css
@@ -1,0 +1,239 @@
+.recipe-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+/* ── Server error banner ── */
+.recipe-form__server-errors {
+  background: #f8d7da;
+  border: 1px solid #f5c6cb;
+  border-radius: 8px;
+  padding: 0.75rem 1rem;
+  color: var(--color-hard);
+  font-size: 0.9rem;
+}
+
+.recipe-form__server-errors ul {
+  margin: 0.25rem 0 0 1.25rem;
+}
+
+/* ── Form groups ── */
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  flex: 1;
+}
+
+.form-group label {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.form-group input,
+.form-group textarea,
+.form-group select {
+  padding: 0.55rem 0.75rem;
+  border: 2px solid var(--color-border);
+  border-radius: 8px;
+  font-size: 0.9rem;
+  color: var(--color-text);
+  background: var(--color-surface);
+  outline: none;
+  transition: border-color 0.15s;
+  font-family: inherit;
+  width: 100%;
+}
+
+.form-group input:focus,
+.form-group textarea:focus,
+.form-group select:focus {
+  border-color: var(--color-primary);
+}
+
+.form-group--error input,
+.form-group--error textarea,
+.form-group--error select {
+  border-color: var(--color-hard);
+}
+
+.form-error {
+  font-size: 0.8rem;
+  color: var(--color-hard);
+  margin-top: 0.1rem;
+}
+
+/* ── Side-by-side rows ── */
+.form-row {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.form-row .form-group {
+  flex: 1;
+  min-width: 140px;
+}
+
+/* ── Fieldsets (ingredients / steps) ── */
+.form-fieldset {
+  border: 2px solid var(--color-border);
+  border-radius: var(--radius);
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.form-fieldset--error {
+  border-color: var(--color-hard);
+}
+
+.form-fieldset legend {
+  font-size: 0.875rem;
+  font-weight: 700;
+  color: var(--color-text);
+  padding: 0 0.35rem;
+}
+
+/* ── Ingredient rows ── */
+.ingredient-rows {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.ingredient-row {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.ingredient-row input {
+  padding: 0.45rem 0.6rem;
+  border: 2px solid var(--color-border);
+  border-radius: 6px;
+  font-size: 0.875rem;
+  color: var(--color-text);
+  background: var(--color-surface);
+  outline: none;
+  font-family: inherit;
+  transition: border-color 0.15s;
+}
+
+.ingredient-row input:focus {
+  border-color: var(--color-primary);
+}
+
+.ingredient-row__amount { width: 70px; flex-shrink: 0; }
+.ingredient-row__unit   { width: 90px; flex-shrink: 0; }
+.ingredient-row__name   { flex: 1; min-width: 120px; }
+
+/* ── Step rows ── */
+.step-rows {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.step-row {
+  display: flex;
+  gap: 0.5rem;
+  align-items: flex-start;
+}
+
+.step-row__number {
+  flex-shrink: 0;
+  width: 1.75rem;
+  height: 1.75rem;
+  border-radius: 50%;
+  background: var(--color-primary);
+  color: #fff;
+  font-size: 0.8rem;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-top: 0.45rem;
+}
+
+.step-row textarea {
+  flex: 1;
+  padding: 0.45rem 0.6rem;
+  border: 2px solid var(--color-border);
+  border-radius: 6px;
+  font-size: 0.875rem;
+  color: var(--color-text);
+  background: var(--color-surface);
+  outline: none;
+  font-family: inherit;
+  resize: vertical;
+  transition: border-color 0.15s;
+}
+
+.step-row textarea:focus {
+  border-color: var(--color-primary);
+}
+
+/* ── Add / remove buttons ── */
+.btn-add {
+  align-self: flex-start;
+  padding: 0.35rem 0.85rem;
+  border: 2px dashed var(--color-border);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--color-text-muted);
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: border-color 0.15s, color 0.15s;
+}
+
+.btn-add:hover {
+  border-color: var(--color-primary);
+  color: var(--color-primary);
+}
+
+.btn-icon {
+  flex-shrink: 0;
+  width: 1.75rem;
+  height: 1.75rem;
+  border: none;
+  border-radius: 50%;
+  background: #f8d7da;
+  color: var(--color-hard);
+  font-size: 0.75rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.15s;
+}
+
+.btn-icon:hover:not(:disabled) {
+  background: var(--color-hard);
+  color: #fff;
+}
+
+.btn-icon:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
+/* ── Submit footer ── */
+.recipe-form__footer {
+  padding-top: 0.5rem;
+}
+
+.btn--primary {
+  background: var(--color-primary);
+  color: #fff;
+  padding: 0.65rem 2rem;
+  font-size: 1rem;
+}
+
+.btn--primary:hover:not(:disabled) {
+  background: var(--color-primary-dark);
+}

--- a/frontend/src/components/RecipeForm.jsx
+++ b/frontend/src/components/RecipeForm.jsx
@@ -1,0 +1,329 @@
+import { useState } from 'react'
+import './RecipeForm.css'
+
+const CATEGORIES = ['Breakfast', 'Lunch', 'Dinner', 'Dessert', 'Snack']
+const DIFFICULTIES = ['Easy', 'Medium', 'Hard']
+
+const EMPTY_INGREDIENT = { amount: '', unit: '', name: '' }
+const EMPTY_STEP = ''
+
+function validate(fields) {
+  const errors = {}
+
+  if (!fields.title || fields.title.trim().length < 3) {
+    errors.title = 'Title must be at least 3 characters.'
+  } else if (fields.title.trim().length > 100) {
+    errors.title = 'Title must be 100 characters or fewer.'
+  }
+
+  const hasIngredient = fields.ingredients.some((i) => i.name.trim() !== '')
+  if (!hasIngredient) {
+    errors.ingredients = 'Add at least one ingredient with a name.'
+  }
+
+  const hasStep = fields.steps.some((s) => s.trim() !== '')
+  if (!hasStep) {
+    errors.steps = 'Add at least one step.'
+  }
+
+  return errors
+}
+
+export default function RecipeForm({ initialValues, onSubmit, submitLabel = 'Save Recipe' }) {
+  const [fields, setFields] = useState({
+    title: initialValues?.title ?? '',
+    description: initialValues?.description ?? '',
+    category: initialValues?.category ?? CATEGORIES[0],
+    cookTime: initialValues?.cookTime ?? '',
+    difficulty: initialValues?.difficulty ?? DIFFICULTIES[0],
+    servings: initialValues?.servings ?? '',
+    ingredients: initialValues?.ingredients?.length
+      ? initialValues.ingredients
+      : [{ ...EMPTY_INGREDIENT }],
+    steps: initialValues?.steps?.length ? initialValues.steps : [EMPTY_STEP],
+  })
+
+  const [clientErrors, setClientErrors] = useState({})
+  const [serverErrors, setServerErrors] = useState([])
+  const [submitting, setSubmitting] = useState(false)
+
+  // ── Simple field update ──
+  function setField(name, value) {
+    setFields((prev) => ({ ...prev, [name]: value }))
+  }
+
+  // ── Ingredients ──
+  function setIngredient(idx, key, value) {
+    setFields((prev) => {
+      const updated = prev.ingredients.map((ing, i) =>
+        i === idx ? { ...ing, [key]: value } : ing,
+      )
+      return { ...prev, ingredients: updated }
+    })
+  }
+
+  function addIngredient() {
+    setFields((prev) => ({
+      ...prev,
+      ingredients: [...prev.ingredients, { ...EMPTY_INGREDIENT }],
+    }))
+  }
+
+  function removeIngredient(idx) {
+    setFields((prev) => ({
+      ...prev,
+      ingredients: prev.ingredients.filter((_, i) => i !== idx),
+    }))
+  }
+
+  // ── Steps ──
+  function setStep(idx, value) {
+    setFields((prev) => {
+      const updated = prev.steps.map((s, i) => (i === idx ? value : s))
+      return { ...prev, steps: updated }
+    })
+  }
+
+  function addStep() {
+    setFields((prev) => ({ ...prev, steps: [...prev.steps, EMPTY_STEP] }))
+  }
+
+  function removeStep(idx) {
+    setFields((prev) => ({
+      ...prev,
+      steps: prev.steps.filter((_, i) => i !== idx),
+    }))
+  }
+
+  // ── Submit ──
+  async function handleSubmit(e) {
+    e.preventDefault()
+    setServerErrors([])
+
+    const errors = validate(fields)
+    setClientErrors(errors)
+    if (Object.keys(errors).length > 0) return
+
+    // Clean up: drop empty steps / ingredients without name
+    const payload = {
+      ...fields,
+      title: fields.title.trim(),
+      description: fields.description.trim(),
+      cookTime: fields.cookTime !== '' ? Number(fields.cookTime) : null,
+      servings: fields.servings !== '' ? Number(fields.servings) : null,
+      ingredients: fields.ingredients.filter((i) => i.name.trim() !== ''),
+      steps: fields.steps.filter((s) => s.trim() !== ''),
+    }
+
+    setSubmitting(true)
+    try {
+      await onSubmit(payload)
+    } catch (err) {
+      // Try to parse server validation errors array
+      try {
+        const body = JSON.parse(err.message)
+        if (Array.isArray(body)) {
+          setServerErrors(body.map((e) => e.msg || e.message || String(e)))
+        } else {
+          setServerErrors([err.message])
+        }
+      } catch {
+        setServerErrors([err.message])
+      }
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <form className="recipe-form" onSubmit={handleSubmit} noValidate>
+      {/* ── Server errors ── */}
+      {serverErrors.length > 0 && (
+        <div className="recipe-form__server-errors" role="alert">
+          <strong>Could not save recipe:</strong>
+          <ul>
+            {serverErrors.map((msg, i) => (
+              <li key={i}>{msg}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {/* ── Title ── */}
+      <div className={`form-group${clientErrors.title ? ' form-group--error' : ''}`}>
+        <label htmlFor="title">Title *</label>
+        <input
+          id="title"
+          type="text"
+          value={fields.title}
+          onChange={(e) => setField('title', e.target.value)}
+          placeholder="e.g. Spaghetti Carbonara"
+          maxLength={100}
+        />
+        {clientErrors.title && <p className="form-error">{clientErrors.title}</p>}
+      </div>
+
+      {/* ── Description ── */}
+      <div className="form-group">
+        <label htmlFor="description">Description</label>
+        <textarea
+          id="description"
+          value={fields.description}
+          onChange={(e) => setField('description', e.target.value)}
+          placeholder="A short description of the recipe…"
+          rows={3}
+          maxLength={500}
+        />
+      </div>
+
+      {/* ── Category + Difficulty row ── */}
+      <div className="form-row">
+        <div className="form-group">
+          <label htmlFor="category">Category</label>
+          <select
+            id="category"
+            value={fields.category}
+            onChange={(e) => setField('category', e.target.value)}
+          >
+            {CATEGORIES.map((c) => (
+              <option key={c} value={c}>{c}</option>
+            ))}
+          </select>
+        </div>
+
+        <div className="form-group">
+          <label htmlFor="difficulty">Difficulty</label>
+          <select
+            id="difficulty"
+            value={fields.difficulty}
+            onChange={(e) => setField('difficulty', e.target.value)}
+          >
+            {DIFFICULTIES.map((d) => (
+              <option key={d} value={d}>{d}</option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      {/* ── Cook time + Servings row ── */}
+      <div className="form-row">
+        <div className="form-group">
+          <label htmlFor="cookTime">Cook Time (minutes)</label>
+          <input
+            id="cookTime"
+            type="number"
+            min={1}
+            max={1440}
+            value={fields.cookTime}
+            onChange={(e) => setField('cookTime', e.target.value)}
+            placeholder="e.g. 30"
+          />
+        </div>
+
+        <div className="form-group">
+          <label htmlFor="servings">Servings</label>
+          <input
+            id="servings"
+            type="number"
+            min={1}
+            max={100}
+            value={fields.servings}
+            onChange={(e) => setField('servings', e.target.value)}
+            placeholder="e.g. 4"
+          />
+        </div>
+      </div>
+
+      {/* ── Ingredients ── */}
+      <fieldset className={`form-fieldset${clientErrors.ingredients ? ' form-fieldset--error' : ''}`}>
+        <legend>Ingredients *</legend>
+        {clientErrors.ingredients && (
+          <p className="form-error">{clientErrors.ingredients}</p>
+        )}
+        <div className="ingredient-rows">
+          {fields.ingredients.map((ing, idx) => (
+            <div key={idx} className="ingredient-row">
+              <input
+                type="text"
+                value={ing.amount}
+                onChange={(e) => setIngredient(idx, 'amount', e.target.value)}
+                placeholder="Amount"
+                className="ingredient-row__amount"
+                aria-label={`Ingredient ${idx + 1} amount`}
+              />
+              <input
+                type="text"
+                value={ing.unit}
+                onChange={(e) => setIngredient(idx, 'unit', e.target.value)}
+                placeholder="Unit"
+                className="ingredient-row__unit"
+                aria-label={`Ingredient ${idx + 1} unit`}
+              />
+              <input
+                type="text"
+                value={ing.name}
+                onChange={(e) => setIngredient(idx, 'name', e.target.value)}
+                placeholder="Name *"
+                className="ingredient-row__name"
+                aria-label={`Ingredient ${idx + 1} name`}
+              />
+              <button
+                type="button"
+                className="btn-icon btn-icon--remove"
+                onClick={() => removeIngredient(idx)}
+                disabled={fields.ingredients.length <= 1}
+                aria-label={`Remove ingredient ${idx + 1}`}
+              >
+                ✕
+              </button>
+            </div>
+          ))}
+        </div>
+        <button type="button" className="btn-add" onClick={addIngredient}>
+          + Add ingredient
+        </button>
+      </fieldset>
+
+      {/* ── Steps ── */}
+      <fieldset className={`form-fieldset${clientErrors.steps ? ' form-fieldset--error' : ''}`}>
+        <legend>Steps *</legend>
+        {clientErrors.steps && (
+          <p className="form-error">{clientErrors.steps}</p>
+        )}
+        <div className="step-rows">
+          {fields.steps.map((step, idx) => (
+            <div key={idx} className="step-row">
+              <span className="step-row__number">{idx + 1}</span>
+              <textarea
+                value={step}
+                onChange={(e) => setStep(idx, e.target.value)}
+                placeholder={`Step ${idx + 1}…`}
+                rows={2}
+                aria-label={`Step ${idx + 1}`}
+              />
+              <button
+                type="button"
+                className="btn-icon btn-icon--remove"
+                onClick={() => removeStep(idx)}
+                disabled={fields.steps.length <= 1}
+                aria-label={`Remove step ${idx + 1}`}
+              >
+                ✕
+              </button>
+            </div>
+          ))}
+        </div>
+        <button type="button" className="btn-add" onClick={addStep}>
+          + Add step
+        </button>
+      </fieldset>
+
+      {/* ── Submit ── */}
+      <div className="recipe-form__footer">
+        <button type="submit" className="btn btn--primary" disabled={submitting}>
+          {submitting ? 'Saving…' : submitLabel}
+        </button>
+      </div>
+    </form>
+  )
+}

--- a/frontend/src/pages/AddRecipePage.jsx
+++ b/frontend/src/pages/AddRecipePage.jsx
@@ -1,10 +1,21 @@
-import { Link } from 'react-router-dom'
+import { useNavigate, Link } from 'react-router-dom'
+import { createRecipe } from '../api/recipes.js'
+import RecipeForm from '../components/RecipeForm.jsx'
+import './FormPage.css'
 
 export default function AddRecipePage() {
+  const navigate = useNavigate()
+
+  async function handleSubmit(payload) {
+    const created = await createRecipe(payload)
+    navigate(`/recipes/${created.id}`)
+  }
+
   return (
-    <div style={{ padding: '2rem', textAlign: 'center' }}>
-      <p>Add recipe form — coming soon.</p>
-      <Link to="/">← Back to recipes</Link>
+    <div className="form-page">
+      <Link to="/" className="form-page__back">← Back to recipes</Link>
+      <h1 className="form-page__title">Add New Recipe</h1>
+      <RecipeForm onSubmit={handleSubmit} submitLabel="Create Recipe" />
     </div>
   )
 }

--- a/frontend/src/pages/EditRecipePage.jsx
+++ b/frontend/src/pages/EditRecipePage.jsx
@@ -1,10 +1,56 @@
-import { Link } from 'react-router-dom'
+import { useState, useEffect } from 'react'
+import { useParams, useNavigate, Link } from 'react-router-dom'
+import { getRecipe, updateRecipe } from '../api/recipes.js'
+import RecipeForm from '../components/RecipeForm.jsx'
+import './FormPage.css'
 
 export default function EditRecipePage() {
+  const { id } = useParams()
+  const navigate = useNavigate()
+
+  const [recipe, setRecipe] = useState(null)
+  const [loading, setLoading] = useState(true)
+  const [notFound, setNotFound] = useState(false)
+
+  useEffect(() => {
+    setLoading(true)
+    getRecipe(id)
+      .then((data) => setRecipe(data))
+      .catch((err) => {
+        if (err.message === 'Recipe not found' || err.message.includes('404')) {
+          setNotFound(true)
+        }
+      })
+      .finally(() => setLoading(false))
+  }, [id])
+
+  async function handleSubmit(payload) {
+    await updateRecipe(id, payload)
+    navigate(`/recipes/${id}`)
+  }
+
+  if (loading) {
+    return <div className="form-page__status">Loading recipe…</div>
+  }
+
+  if (notFound) {
+    return (
+      <div className="form-page__status form-page__status--notfound">
+        <p>Recipe not found.</p>
+        <Link to="/">← Back to recipes</Link>
+      </div>
+    )
+  }
+
   return (
-    <div style={{ padding: '2rem', textAlign: 'center' }}>
-      <p>Edit recipe form — coming soon.</p>
-      <Link to="/">← Back to recipes</Link>
+    <div className="form-page">
+      <Link to={`/recipes/${id}`} className="form-page__back">← Back to recipe</Link>
+      <h1 className="form-page__title">Edit Recipe</h1>
+      <RecipeForm
+        initialValues={recipe}
+        onSubmit={handleSubmit}
+        submitLabel="Save Changes"
+      />
     </div>
   )
 }

--- a/frontend/src/pages/FormPage.css
+++ b/frontend/src/pages/FormPage.css
@@ -1,0 +1,35 @@
+.form-page {
+  max-width: 700px;
+  margin: 0 auto;
+}
+
+.form-page__back {
+  display: inline-block;
+  margin-bottom: 1.25rem;
+  font-size: 0.9rem;
+  color: var(--color-text-muted);
+}
+
+.form-page__back:hover {
+  color: var(--color-primary);
+}
+
+.form-page__title {
+  font-size: 1.6rem;
+  font-weight: 700;
+  margin-bottom: 1.5rem;
+  color: var(--color-text);
+}
+
+.form-page__status {
+  text-align: center;
+  padding: 4rem 1rem;
+  color: var(--color-text-muted);
+}
+
+.form-page__status--notfound {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+}


### PR DESCRIPTION
Feature #4 for Issue #1

Build AddRecipePage at /recipes/new and EditRecipePage at /recipes/:id/edit.

**Implemented:**
- `RecipeForm.jsx` — shared form with all fields: title, description, category select, cookTime, difficulty select, servings, dynamic ingredients (amount+unit+name), dynamic steps (textarea)
- Dynamic ingredient rows — add/remove, remove disabled when only 1 row
- Dynamic step rows — numbered, add/remove, remove disabled when only 1 row
- Client-side validation: title 3-100 chars, ≥1 ingredient with name, ≥1 non-empty step
- Server-side validation: 400 `{errors:[]}` responses shown as banner
- `AddRecipePage.jsx` — POST → redirects to `/recipes/:newId`
- `EditRecipePage.jsx` — fetches recipe on mount, pre-populates all fields, PUT → redirects to `/recipes/:id`; loading + 404 states
- `api/recipes.js` — updated to surface express-validator error arrays
- `npm run build` passes (57 modules) ✅

---
*Created by Antigravity Dev Agent*