### PR TITLE
fix(e2e): search filter matches ingredient name not description

### DIFF
--- a/backend/routes/recipes.js
+++ b/backend/routes/recipes.js
@@ -62,7 +62,7 @@ router.get('/', (req, res) => {
     recipes = recipes.filter(
       (r) =>
         r.title.toLowerCase().includes(term) ||
-        (r.description && r.description.toLowerCase().includes(term))
+        r.ingredients.some((i) => i.name.toLowerCase().includes(term))
     );
   }
 


### PR DESCRIPTION
E2E fix for Issue #1 — cycle 1

**Failure:** B2 — `GET /api/recipes?search=flour` returned 0 results (expected 2).

**Root cause:** `backend/routes/recipes.js` search filter was checking `r.description` instead of ingredient names, violating the PM spec:
> Search: Case-insensitive match on `title` OR any ingredient `name`.

This fix was applied in the Feature 1 QA re-run on `feature/issue-1-feat-1` but was not included in the main feature merge.

**Fix (1 line):**
```js
// Before (wrong)
(r.description && r.description.toLowerCase().includes(term))

// After (correct)
r.ingredients.some((i) => i.name.toLowerCase().includes(term))
```

**Verified:**
- `?search=flour` → 2 results (Classic Buttermilk Pancakes, Chocolate Lava Cakes) ✅
- `?search=quinoa` → 1 result (title match) ✅
- `?search=paprika` → 1 result (ingredient match) ✅
- All other B tests unaffected ✅

---
*Created by Antigravity Dev Agent*